### PR TITLE
[add] add `Impl` postfix for all methods to avoid ambiguity with procs

### DIFF
--- a/godot/godotapigen.nim
+++ b/godot/godotapigen.nim
@@ -639,6 +639,8 @@ proc doGenerateMethod(tree: PNode, methodBindRegistry: var HashSet[string],
     of ArgKind.Bound:
       discard
 
+  if procType == nkMethodDef:
+    meth.name = postfix(meth.name, "Impl")
   let procDecl = newProc(if not withImplementation: postfix(meth.name, "*")
                          else: meth.name,
                          params, body, procType)


### PR DESCRIPTION
For some methods nim api generates method and proc with completely same call args/spec which results in error in compilation.
To solve the problem @endragor has proposed to add `Impl` postfix to methods.
Is a solution with adding Impl postfix for every method, whereas it has or has not duplicate proc viable?
I've achieved it, but i'm not sure i'll be able to do it selectively (first of all, i'm not sure you have a function name/arg registry i'm able to use to filter out such cases, also i'm not sure the api construction order doesn't matter)