### PR TITLE
Nim 0.19/devel compatibility

### DIFF
--- a/docs/docbuild.nim
+++ b/docs/docbuild.nim
@@ -71,7 +71,7 @@ proc fixupHrefs(file: string) =
 
 proc getGitHash(): string =
   result = execProcess("git rev-parse HEAD")
-  if not result.isNil and result.len > 0:
+  if result.len > 0:
     result = result.replace("\L", "").replace("\r", "")
 
 proc buildDocs*(outDir, godotNimDir, godotBin: string) =
@@ -112,7 +112,7 @@ proc buildDocs*(outDir, godotNimDir, godotBin: string) =
   var gitHash: string
   withDir(godotBinAbs.parentDir()):
     gitHash = getGitHash()
-    if gitHash.isNil or gitHash.len == 0:
+    if gitHash.len == 0:
       raise newException(Exception,
         "Godot executable is not under Git repository")
 

--- a/godot.nimble
+++ b/godot.nimble
@@ -1,4 +1,4 @@
-version = "0.7.18"
+version = "0.7.19"
 author = "Xored Software, Inc."
 description = "Godot Engine bindings"
 license = "MIT"

--- a/godot/core/variants.nim
+++ b/godot/core/variants.nim
@@ -73,12 +73,9 @@ proc newVariant*(r: cdouble): Variant {.inline.} =
 
 proc newVariant*(s: string): Variant {.inline.} =
   new(result, variantFinalizer)
-  if s.isNil:
-    initGodotVariant(result.godotVariant)
-  else:
-    var godotStr = s.toGodotString()
-    initGodotVariant(result.godotVariant, godotStr)
-    godotStr.deinit()
+  var godotStr = s.toGodotString()
+  initGodotVariant(result.godotVariant, godotStr)
+  godotStr.deinit()
 
 import basis, nodepaths
 import planes, quats, rect2, aabb, rids

--- a/godot/godotapigen.nim
+++ b/godot/godotapigen.nim
@@ -456,7 +456,7 @@ proc doGenerateMethod(tree: PNode, methodBindRegistry: var HashSet[string],
             ident("array"), ident("MAX_ARG_COUNT"),
             if isVarargs: newNode(nkPtrTy).addChain(ident("GodotVariant"))
             else: ident("pointer"))))
-      staticArgsLen = if varargsName.isSome: meth.args.len
+      staticArgsLen = if varargsName.isNone: meth.args.len
                       else: meth.args.len - 1
       if varargsName.isSome:
         argLenNode = newCall("cint",

--- a/godot/internal/godotstrings.nim
+++ b/godot/internal/godotstrings.nim
@@ -38,10 +38,7 @@ proc `$`*(self: GodotString): string =
 
 proc toGodotString*(s: string): GodotString {.inline.} =
   ## Converts the Nim string into ``GodotString``
-  if s.isNil:
-    initGodotString(result)
-  else:
-    initGodotString(result, cstring(s), cint(s.len + 1))
+  initGodotString(result, cstring(s), cint(s.len + 1))
 
 proc toGodotString*(s: cstring): GodotString {.inline.} =
   ## Converts the cstring into ``GodotString``

--- a/godot/nim/godotmacros.nim
+++ b/godot/nim/godotmacros.nim
@@ -509,9 +509,11 @@ proc genType(obj: ObjectDecl): NimNode {.compileTime.} =
   let classNameIdent = ident(obj.name)
   let isRef: bool = if obj.parentName == "": false
                     else: obj.parentName in refClasses
+  # Wrapping bools with a newLit is required as a temporary workaround for
+  # https://github.com/nim-lang/Nim/issues/7375
   result.add(getAst(
-    registerGodotClass(classNameIdent, classNameLit, isRef, parentName,
-                       genSym(nskProc, "createFunc"), obj.isTool)))
+    registerGodotClass(classNameIdent, classNameLit, newLit(isRef), parentName,
+                       genSym(nskProc, "createFunc"), newLit(obj.isTool))))
 
   # Register fields (properties)
   for field in obj.fields:

--- a/godot/nim/godotmacros.nim
+++ b/godot/nim/godotmacros.nim
@@ -545,7 +545,7 @@ proc genType(obj: ObjectDecl): NimNode {.compileTime.} =
                                methodNameLit, minArgs, maxArgs,
                                argTypes, methFuncIdent, hasReturnValue) =
     {.emit: """/*TYPESECTION*/
-N_NOINLINE(void, setStackBottom)(void* thestackbottom);
+N_NOINLINE(void, nimGC_setStackBottom)(void* thestackbottom);
 """.}
     proc methFuncIdent(obj: ptr GodotObject, methodData: pointer,
                        userData: pointer, numArgs: cint,
@@ -553,7 +553,7 @@ N_NOINLINE(void, setStackBottom)(void* thestackbottom);
                       GodotVariant {.noconv.} =
       var stackBottom {.volatile.}: pointer
       {.emit: """
-        setStackBottom((void*)(&`stackBottom`));
+      nimGC_setStackBottom((void*)(&`stackBottom`));
       """.}
       let self = cast[classNameIdent](userData)
       const isStaticCall = methodNameLit == cstring"_ready" or

--- a/godot/nim/godotnim.nim
+++ b/godot/nim/godotnim.nim
@@ -831,7 +831,7 @@ proc fromVariant*[T: Table or TableRef or OrderedTable or OrderedTableRef](t: va
 
 {.emit: """/*TYPESECTION*/
 N_LIB_EXPORT N_CDECL(void, NimMain)(void);
-N_NOINLINE(void, setStackBottom)(void* thestackbottom);
+N_NOINLINE(void, nimGC_setStackBottom)(void* thestackbottom);
 """.}
 
 var nativeLibHandle: pointer
@@ -847,7 +847,7 @@ proc godot_nativescript_init(handle: pointer) {.
   var stackBottom {.volatile.}: pointer
   {.emit: """
     NimMain();
-    setStackBottom((void*)(&`stackBottom`));
+    nimGC_setStackBottom((void*)(&`stackBottom`));
   """.}
   GC_fullCollect()
   GC_disable()
@@ -884,7 +884,7 @@ proc registerFrameCallback*(cb: proc () {.closure.}) =
 proc godot_nativescript_frame() {.cdecl, exportc, dynlib.} =
   var stackBottom {.volatile.}: pointer
   {.emit: """
-  setStackBottom((void*)(&`stackBottom`));
+  nimGC_setStackBottom((void*)(&`stackBottom`));
   """.}
   for cb in idleCallbacks:
     cb()

--- a/godot/nim/godotnim.nim
+++ b/godot/nim/godotnim.nim
@@ -343,23 +343,20 @@ proc newRStrLit(s: string): NimNode {.compileTime.} =
   result = newNimNode(nnkRStrLit)
   result.strVal = s
 
-macro toGodotName(T: typedesc): string =
-  var godotName =
-    if T is GodotString or T is string:
-      "String"
-    elif T is SomeFloat:
-      "float"
-    elif T is SomeUnsignedInt or T is SomeSignedInt:
-      "int"
-    else:
-      let nameStr = (($T.getType()[1][1].symbol).split(':')[0])
-      case nameStr:
-        of "File", "Directory", "Thread", "Mutex", "Semaphore":
-          "_" & nameStr
-        else:
-          nameStr
-
-  result = newLit(godotName)
+proc toGodotName(T: typedesc): string =
+  if T is GodotString or T is string:
+    "String"
+  elif T is SomeFloat:
+    "float"
+  elif T is SomeUnsignedInt or T is SomeSignedInt:
+    "int"
+  else:
+    let nameStr = (($T.getType()[1][1].symbol).split(':')[0])
+    case nameStr:
+      of "File", "Directory", "Thread", "Mutex", "Semaphore":
+        "_" & nameStr
+      else:
+        nameStr
 
 macro asCString(s: static[string]): cstring =
   result = newNimNode(nnkCallStrLit).add(


### PR DESCRIPTION
Attempt to fix #41

I addressed the most obvious issues regarding Nim 0.19. 

Unfortunately, I still can't compile the nim-godot-stub, because there is now a very strange macro error:

```
fpscounter.nim(7, 7) template/generic instantiation of `gdobj` from here
fpscounter.nim(10, 3) Warning: the '.this' pragma is deprecated [Deprecated]
fpscounter.nim(7, 7) template/generic instantiation of `gdobj` from here
../../godot-nim/godot/nim/godotmacros.nim(513, 23) Error: type mismatch: got <int literal(0)> but expected 'bool'
```

This is referring to the code line:

```nimrod
  result.add(getAst(
    registerGodotClass(classNameIdent, classNameLit, isRef, parentName,
                       genSym(nskProc, "createFunc"), obj.isTool)))
```

As far as I can see from stdout debugging none of the arguments is an `int literal (0)`. Is this a Nim bug?
