### PR TITLE
Added moveToward for vectors.

### DIFF
--- a/godot/core/vector2.nim
+++ b/godot/core/vector2.nim
@@ -5,6 +5,8 @@ import math, godotbase, hashes
 import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 
+const EPSILON = 0.00001'f32
+
 {.push stackTrace: off.}
 
 proc vec2*(): Vector2 {.inline, noinit.} =
@@ -198,5 +200,15 @@ proc clamped*(self: Vector2; length: float32): Vector2 {.noinit.} =
   if len > 0 and length < len:
     result /= len
     result *= length
+
+proc moveToward*(vFrom, to: Vector2, delta: float32): Vector2 =
+  let
+    vd = to - vFrom
+    vLen = vd.length
+
+  if vLen <= delta or vLen < EPSILON:
+    result = to
+  else:
+    result = vFrom + (vd / vLen) * delta
 
 {.pop.} # stackTrace: off

--- a/godot/core/vector3.nim
+++ b/godot/core/vector3.nim
@@ -3,6 +3,8 @@
 import math, hashes
 import godotbase, godotcoretypes
 
+const EPSILON = 0.00001'f32
+
 {.push stackTrace: off.}
 
 proc vec3*(): Vector3 {.inline.} =
@@ -238,5 +240,15 @@ proc cubicInterpolate*(self, b, preA, postB: Vector3;
             (-p0 + p2) * t +
             (2.0 * p0 - 5.0 * p1 + 4 * p2 - p3) * t2 +
             (-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3)
+
+proc moveToward*(vFrom, to: Vector3, delta: float32): Vector3 =
+  let
+    vd = to - vFrom
+    vLen = vd.length
+
+  if vLen <= delta or vLen < EPSILON:
+    result = to
+  else:
+    result = vFrom + (vd / vLen) * delta
 
 {.pop.} # stackTrace: off


### PR DESCRIPTION
This is a small additive change, which adds a `moveTowards` function for `Vector2` and `Vector3` that was added in Godot 3.2.

Implementation is taken from the [GDNative C++ library](https://github.com/godotengine/godot/blob/master/modules/gdnative/gdnative/vector2.cpp).