### PR TITLE
added signal declaration

### DIFF
--- a/godot/internal/godotinternaltypes.nim
+++ b/godot/internal/godotinternaltypes.nim
@@ -92,14 +92,14 @@ type
     RID,
     Object,
     Dictionary,
-    Array, ##  20
+    Array,
     # arrays
-    PoolByteArray,
+    PoolByteArray, ## 20
     PoolIntArray,
     PoolRealArray,
     PoolStringArray,
-    PoolVector2Array, ##  25
-    PoolVector3Array,
+    PoolVector2Array,
+    PoolVector3Array, ## 25
     PoolColorArray
 
   VariantCallErrorType* {.size: sizeof(cint), pure.} = enum
@@ -291,7 +291,7 @@ type
     methodData*: pointer
     freeFunc*: proc (a2: pointer) {.noconv.}
 
-  GodotSignalArgument* {.bycopy.} = object
+  GodotSignalArgument* {.bycopy, packed.} = object
     name*: GodotString
     typ*: cint
     hint*: GodotPropertyHint


### PR DESCRIPTION
Now we can define signals without having to resort to addUserSignal like this:
```nim
import godot
import godotapi / sprite

gdobj MySprite of Sprite:

  signal my_signal(a:int, b:bool, c:string) 

  method ready() =
    self.connect("my_signal", self, "on_my_signal")
    self.emit_signal("my_signal", 123.toVariant, true.toVariant, "^_^".toVariant)

  proc on_my_signal(a:int, b:bool, c:string) {.gdExport.} =
    print &"got signal {a} {b} {c}"
```