### PR TITLE
added async handling for signals

### DIFF
--- a/godot/internal/godotinternaltypes.nim
+++ b/godot/internal/godotinternaltypes.nim
@@ -92,14 +92,14 @@ type
     RID,
     Object,
     Dictionary,
-    Array, ##  20
+    Array,
     # arrays
-    PoolByteArray,
+    PoolByteArray, ## 20
     PoolIntArray,
     PoolRealArray,
     PoolStringArray,
-    PoolVector2Array, ##  25
-    PoolVector3Array,
+    PoolVector2Array,
+    PoolVector3Array, ## 25
     PoolColorArray
 
   VariantCallErrorType* {.size: sizeof(cint), pure.} = enum
@@ -291,7 +291,7 @@ type
     methodData*: pointer
     freeFunc*: proc (a2: pointer) {.noconv.}
 
-  GodotSignalArgument* {.bycopy.} = object
+  GodotSignalArgument* {.bycopy, packed.} = object
     name*: GodotString
     typ*: cint
     hint*: GodotPropertyHint


### PR DESCRIPTION
So we can handle signals with an {.async.} proc like this:

```nim
...
import asynchdispatch

gdobj SpriteComp of Sprite:

  signal bsclick(button_idx:int, shape_idx:int)

  method ready() =
    ...
    registerFrameCallback(
      proc() =
        if hasPendingOperations():
          poll(0)
    )
    asyncCheck self.fireTimer()
    self.emit_signal("bsclick", 1.toVariant, 0.toVariant)

  proc fireTimer() {.async.} =
    await on_signal(self.get_tree().createTimer(1), "timeout")
    print "timeout sceneTree"

    var vals = await on_signal(self, "bsclick", tuple[button_idx:int, shape_idx:int])
    print &"bsclick {vals.button_idx = } {vals.shape_idx = }"
```