### PR TITLE
gdexport on method exports without transforming

### DIFF
--- a/godot/nim/godotmacros.nim
+++ b/godot/nim/godotmacros.nim
@@ -22,6 +22,7 @@ type
     returnType: NimNode
     nimNode: NimNode
     isNoGodot: bool
+    isGdExport:bool
 
   ObjectDecl = ref object
     name: string
@@ -164,6 +165,7 @@ proc parseMethod(meth: NimNode): MethodDecl =
     returnType: meth[3][0],
     isVirtual: meth.kind == nnkMethodDef,
     isNoGodot: isNoGodot,
+    isGdExport: isGdExport,
     nimNode: meth
   )
   for i in 1..<meth[3].len:
@@ -605,7 +607,7 @@ N_NOINLINE(void, setStackBottom)(void* thestackbottom);
         minArgs = idx
       argTypes.add(arg.typ)
 
-    let godotMethodName = if meth.isVirtual: "_" & toGodotStyle(meth.name)
+    let godotMethodName = if meth.isVirtual and not meth.isGdExport: "_" & toGodotStyle(meth.name)
                           else: toGodotStyle(meth.name)
     let hasReturnValueBool = not (meth.returnType.isNil or
                          meth.returnType.kind == nnkEmpty or


### PR DESCRIPTION
Fixes https://github.com/pragmagic/godot-nim/issues/87
Now adding gdExport on  a method exports it like proc.  So `method doIt() {.gdExport.}` exports as `do_it` instead of `_do_it`.  So godot can find our virtual methods that don't begin with underscores.