### PR TITLE
Support nim case insensitivity in pragmas

### DIFF
--- a/godot/nim/godotmacros.nim
+++ b/godot/nim/godotmacros.nim
@@ -94,7 +94,7 @@ proc removePragmaNode(statement: NimNode,
   var pragmas = if RoutineNodes.contains(statement.kind): statement.pragma()
                 else: statement[1]
   for ident, val, i in pragmas(pragmas):
-    if ident == pname:
+    if ident.eqIdent(pname):
       pragmas.del(i)
       return val
 
@@ -106,7 +106,7 @@ proc removePragma(statement: NimNode, pname: string): bool =
   var pragmas = if RoutineNodes.contains(statement.kind): statement.pragma()
                 else: statement[1]
   for ident, val, i in pragmas(pragmas):
-    if ident == pname:
+    if ident.eqIdent(pname):
       pragmas.del(i)
       return true
 


### PR DESCRIPTION
Prior to this change `gdexport` or similar would not be considered the same as `gdExport` which is just wrong for Nim identifers.