### PR TITLE
fixed bug in basis transpose

### DIFF
--- a/godot/core/basis.nim
+++ b/godot/core/basis.nim
@@ -283,7 +283,7 @@ proc orthonormalized*(self: Basis): Basis {.inline.} =
   result.orthonormalize()
 
 proc transpose*(self: var Basis) {.inline.} =
-  swap(self.elements[0].x, self.elements[1].x)
+  swap(self.elements[0].y, self.elements[1].x)
   swap(self.elements[0].z, self.elements[2].x)
   swap(self.elements[1].z, self.elements[2].y)
 


### PR DESCRIPTION
https://github.com/pragmagic/godot-nim/blob/7fb22f69af92aa916e56dba14ba3938fc7fa1dd1/godot/core/basis.nim#L286
This should be.
`swap(self.elements[0].y, self.elements[1].x)` 