### PR TITLE
Fixes for 0 length seqs and strings

### DIFF
--- a/godot/internal/godotstrings.nim
+++ b/godot/internal/godotstrings.nim
@@ -33,7 +33,8 @@ proc `$`*(self: GodotString): string =
   var charStr = getGDNativeAPI().stringUtf8(self)
   let length = getGDNativeAPI().charStringLength(charStr)
   result = newString(length)
-  copyMem(addr result[0], getGDNativeAPI().charStringGetData(charStr), length)
+  if length > 0:
+    copyMem(addr result[0], getGDNativeAPI().charStringGetData(charStr), length)
   getGDNativeAPI().charStringDestroy(charStr)
 
 proc toGodotString*(s: string): GodotString {.inline.} =

--- a/godot/nim/godotnim.nim
+++ b/godot/nim/godotnim.nim
@@ -759,8 +759,9 @@ template arrayToVariant(s: untyped): Variant =
   newVariant(arr)
 
 proc toVariant*[T](s: seq[T]): Variant =
-  if s.isNil:
-    return newVariant()
+  when (NimMajor, NimMinor, NimPatch) < (0, 20, 0):
+    if s.isNil:
+      return newVariant()
   result = arrayToVariant(s)
 
 proc toVariant*[I, T](s: array[I, T]): Variant =
@@ -768,7 +769,10 @@ proc toVariant*[I, T](s: array[I, T]): Variant =
 
 proc fromVariant*[T](s: var seq[T], val: Variant): ConversionResult =
   if val.getType() == VariantType.Nil:
-    s = nil
+    when (NimMajor, NimMinor, NimPatch) < (0, 20, 0):
+      s = nil
+    else:
+      result = ConversionResult.TypeError
   elif val.getType() == VariantType.Array:
     let arr = val.asArray()
     var newS = newSeq[T](arr.len)


### PR DESCRIPTION
Quick fixes for bugs I encountered dealing with 0 length seqs and strings in newer versions of nim.