### PR TITLE
Added abillity to generate templates to prevent needing to write 'self.'

### DIFF
--- a/godot/nim/godotmacros.nim
+++ b/godot/nim/godotmacros.nim
@@ -491,6 +491,12 @@ proc genType(obj: ObjectDecl): NimNode {.compileTime.} =
       ident("this"), ident("self")
     )))
 
+  when defined(godotSelflessFields): # User controllable
+    for field in obj.fields: # adds templates for fields so we dont need silly self.
+      let name = field.name
+      result.add quote do:
+        template `name`() : untyped = self.`name`
+
   # Nim proc defintions
   var decls = newSeqOfCap[NimNode](obj.methods.len)
   for meth in obj.methods:


### PR DESCRIPTION
Allows user enabled templates to be emitted with `-d:godotSelflessFields` so you only need to use `self.` if there is ambiguity or calling procedures/methods an example is as follows
```nim
#Nim imports
import strutils
import std/strformat

#Godot imports
import godot
include godotapi/godotall

proc isConnected = discard # Here just to show an example of what happens for collision
const SERVER_IP: string = "127.0.0.1"
const PORT: int = 8888

gdobj Client of Node:

  var client: StreamPeerTCP
  var clientStream: PacketPeerStream
  var isConnected = false
  var shouldConnect = false

  method ready*() =
    client = StreamPeerTCP.new()
    client.set_no_delay(true)
    self.connect(10)

  method process*(delta: float64) =
    if shouldConnect and not self.isConnected: # Need to use `self.` with ambiguity
      discard #pass
    if self.isConnected and not client.is_connected_to_host():
      self.isConnected = false
    if client.is_connected_to_host(): # `client` instead of `self.client` thanks to hidden templates
      self.poll()

  method input*(event: InputEvent) =
    if isKeyPressed(KEY_T):
      print("something")

  proc connect(timeout: int): void =
    self.set_process(true)
    shouldConnect = true
    print(fmt"Connecting to {SERVER_IP}:{PORT}")
    var connected = client.connect_to_host(SERVER_IP, PORT)
    if connected == Error.OK:
      if client.is_connected_to_host():
        self.isConnected = true
        print("Connected to server")
        clientStream = PacketPeerStream.new()
        clientStream.streamPeer = client
    else:
      print("Attempt to connect failed.")

  proc disconnect(): void =
    client.disconnect_from_host()

  proc poll(): void =
    discard #pass
 ```